### PR TITLE
Render Vercel Analytics and Speed Insights on all pages

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -100,6 +100,8 @@ function MyApp({ Component, pageProps }) {
     <>
       <Component {...pageProps} />
       <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+      <Analytics />
+      <SpeedInsights />
     </>
   )
 }


### PR DESCRIPTION
The Analytics and SpeedInsights components were imported in _app.js but never rendered, so no analytics were being collected. Render both in the _app root so every page is tracked.